### PR TITLE
Refactor Day 7, using separate threads for IntcodeVM

### DIFF
--- a/Advent of Code/Advent of Code.csproj
+++ b/Advent of Code/Advent of Code.csproj
@@ -2,15 +2,19 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Advent_of_Code</RootNamespace>
     <GenerateProgramFile>false</GenerateProgramFile>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Advent of Code/Day 07/Day_07.cs
+++ b/Advent of Code/Day 07/Day_07.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Linq;
-using System.IO;
 using System.Diagnostics;
 
 namespace Advent_of_Code.Day_07
@@ -33,7 +30,5 @@ namespace Advent_of_Code.Day_07
             Console.WriteLine();
 
         }
-
-
     }
 }

--- a/Advent of Code/Day 07/FeedbackAmplifier.cs
+++ b/Advent of Code/Day 07/FeedbackAmplifier.cs
@@ -1,6 +1,10 @@
 ﻿using Advent_of_Code.SharedLibrary.IntcodeVirtualMachine;
 using Advent_of_Code.SharedLibrary.IntcodeVirtualMachine.Input_OutputProviders;
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 
 namespace Advent_of_Code.Day_07
 {
@@ -9,30 +13,20 @@ namespace Advent_of_Code.Day_07
         private readonly IntcodeVirtualMachine _intcodeVirtualMachine;
         private readonly List<int> _program;
 
-        public bool IsDone
-        {
-            get
-            {
-                return _intcodeVirtualMachine.IsDone;
-            }
-        }
+        public bool IsDone => _intcodeVirtualMachine.IsDone;
+        public void Step() => _intcodeVirtualMachine.Step();
 
-        public Queue<long> InputQueue { get; }
-        public Queue<long> OutputQueue { get; }
+        public void Run() => _intcodeVirtualMachine.Run();
+        public BufferBlock<long> InputBuffer { get; }
+        public BufferBlock<long> OutputBuffer { get; }
 
-        public FeedbackAmplifier(List<int> program, Queue<long> inputQueue, Queue<long> outputQueue)
+        public FeedbackAmplifier(List<int> program, BufferBlock<long> inputBuffer, BufferBlock<long> outputBuffer)
         {
+            InputBuffer = inputBuffer;
+            OutputBuffer = outputBuffer;
             _program = program;
-            InputQueue = inputQueue;
-            OutputQueue = outputQueue;
 
-            _intcodeVirtualMachine = new IntcodeVirtualMachine(_program, new QueueInputProvider(inputQueue), new QueueOutputProvider(outputQueue));
+            _intcodeVirtualMachine = new IntcodeVirtualMachine(_program, new BufferInputProvider(InputBuffer), new BufferOutputProvider(OutputBuffer));
         }
-
-        public void Step()
-        {
-            _intcodeVirtualMachine.Step();
-        }
-
     }
 }

--- a/Advent of Code/Day 07/FeedbackAmplifierTuner.cs
+++ b/Advent of Code/Day 07/FeedbackAmplifierTuner.cs
@@ -57,13 +57,11 @@ namespace Advent_of_Code.Day_07
             Log.Debug("Setting tune");
             for (int i = 0; i < amplifierCount; i++)
             {
-                var tuneElement= i == 0 ? tune[amplifierCount - 1] : tune[i - 1]; // Input to the first should be the output from the last. 
-                buffers[i].Post(tuneElement);
+                amplifiers[i].InputBuffer.Post(tune[i]);
             }
 
             Log.Debug("Priming amplifier 0 with input");
             amplifiers[0].InputBuffer.Post(0);
-
 
             Log.Debug("Running amplifiers");
             amplifiers.ForEach(x => x.Run());

--- a/Advent of Code/Day 07/FeedbackAmplifierTuner.cs
+++ b/Advent of Code/Day 07/FeedbackAmplifierTuner.cs
@@ -4,8 +4,6 @@ using System.Threading.Tasks.Dataflow;
 using System.Threading.Tasks;
 using Serilog;
 using System.Linq;
-using System.Reflection;
-using System;
 
 namespace Advent_of_Code.Day_07
 {
@@ -33,11 +31,10 @@ namespace Advent_of_Code.Day_07
             }
         }
 
-        private long RunFeedbackAmplifier(List<long> tune)
+        private List<BufferBlock<long>> GetEmptyBuffers(List<long> tune)
         {
             int amplifierCount = tune.Count;
             List<BufferBlock<long>> buffers = new List<BufferBlock<long>>();
-            List<FeedbackAmplifier> amplifiers = new List<FeedbackAmplifier>();
 
             Log.Debug("Initalising Buffers");
             for (int i = 0; i < amplifierCount; i++)
@@ -45,7 +42,15 @@ namespace Advent_of_Code.Day_07
                 buffers.Add(new BufferBlock<long>());
             }
 
+            return buffers;
+        }
+
+        private List<FeedbackAmplifier> GetAmplifiers(List<long> tune, List<BufferBlock<long>> buffers)
+        {
             Log.Debug("Initalising Amplifiers");
+            int amplifierCount = tune.Count;
+            List<FeedbackAmplifier> amplifiers = new List<FeedbackAmplifier>();
+
             for (int i = 0; i < amplifierCount; i++)
             {
                 var inputBuffer = i == 0 ? buffers[amplifierCount - 1] : buffers[i - 1]; // Input to the first should be the output from the last. 
@@ -54,26 +59,46 @@ namespace Advent_of_Code.Day_07
                 amplifiers.Add(new FeedbackAmplifier(programCopy, inputBuffer, outputBuffer));
             }
 
+            return amplifiers;
+        }
+
+        private void InitaliseAmplifierTune(List<long> tune, List<FeedbackAmplifier> amplifiers)
+        {
             Log.Debug("Setting tune");
-            for (int i = 0; i < amplifierCount; i++)
+            for (int i = 0; i < amplifiers.Count; i++)
             {
                 amplifiers[i].InputBuffer.Post(tune[i]);
             }
+        }
 
+        private void WriteAmplifierInput(List<FeedbackAmplifier> amplifiers)
+        {
             Log.Debug("Priming amplifier 0 with input");
             amplifiers[0].InputBuffer.Post(0);
+        }
 
+        private void RunAmplifiers(List<FeedbackAmplifier> amplifiers)
+        {
             Log.Debug("Running amplifiers");
             amplifiers.ForEach(x => x.Run());
+        }
 
+        private void WaitForAmplifierCompletion(List<FeedbackAmplifier> amplifiers)
+        {
             Log.Debug("Waiting for any task to complete");
             var tasks = amplifiers.Select(x => x.Task);
             Task.WhenAll(tasks).Wait();
             Log.Debug("All tasks completed");
+        }
 
-            Log.Debug("Cancelling remaining tasks"); // Not currently required, but keeing because it took a while to 
-            amplifiers.ForEach(x => x.Cancel());
-
+        private long RunFeedbackAmplifier(List<long> tune)
+        {
+            List<BufferBlock<long>> buffers = GetEmptyBuffers(tune);
+            List<FeedbackAmplifier> amplifiers = GetAmplifiers(tune, buffers);
+            InitaliseAmplifierTune(tune, amplifiers);
+            WriteAmplifierInput(amplifiers);
+            RunAmplifiers(amplifiers);
+            WaitForAmplifierCompletion(amplifiers);
             return amplifiers[0].InputBuffer.Receive();
         }
 

--- a/Advent of Code/Day 07/Tests/Day7_Solutions_Tests.cs
+++ b/Advent of Code/Day 07/Tests/Day7_Solutions_Tests.cs
@@ -34,6 +34,5 @@ namespace Advent_of_Code.Day_07.Tests
             Assert.Equal(expectedTune, feedbackTuner.OptimalTune);
             Assert.Equal(expectedOutput, feedbackTuner.HighestOutput);
         }
-
     }
 }

--- a/Advent of Code/Program.cs
+++ b/Advent of Code/Program.cs
@@ -1,5 +1,5 @@
-﻿using System;
-
+﻿using Serilog;
+using System;
 
 namespace Advent_of_Code
 {
@@ -7,6 +7,8 @@ namespace Advent_of_Code
     {
         static void Main(string[] args)
         {
+            SetupLogging();
+
             Console.WriteLine("Starting");
             Day_01.Day_01.Run();
 
@@ -50,6 +52,17 @@ namespace Advent_of_Code
             d14.Run();
 
             Console.WriteLine("Complete");
+        }
+
+        private static void SetupLogging()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.WithThreadId()
+                .WriteTo.File(
+                    "DebugLog.log",
+                    rollingInterval: RollingInterval.Day,
+                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} <{ThreadId}>{NewLine}{Exception}")
+                .CreateLogger();
         }
     }
 }

--- a/Advent of Code/SharedLibrary/IntcodeVirtualMachine/Input-OutputProviders/BufferInputProvider.cs
+++ b/Advent of Code/SharedLibrary/IntcodeVirtualMachine/Input-OutputProviders/BufferInputProvider.cs
@@ -1,0 +1,23 @@
+﻿using Serilog;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks.Dataflow;
+
+namespace Advent_of_Code.SharedLibrary.IntcodeVirtualMachine.Input_OutputProviders
+{
+    public class BufferInputProvider : IInputProvider
+    {
+        private readonly BufferBlock<long> _inputBuffer;
+        public BufferInputProvider(BufferBlock<long> inputBuffer)
+        {
+            _inputBuffer = inputBuffer;
+        }
+
+        public long GetInput()
+        {
+            long input = _inputBuffer.Receive();
+            Log.Information("BufferInputProvider Recieved input {output}", input);
+            return input;
+        }
+    }
+}

--- a/Advent of Code/SharedLibrary/IntcodeVirtualMachine/Input-OutputProviders/BufferOutputProvider.cs
+++ b/Advent of Code/SharedLibrary/IntcodeVirtualMachine/Input-OutputProviders/BufferOutputProvider.cs
@@ -1,0 +1,21 @@
+﻿using Serilog;
+using System.Collections.Generic;
+using System.Threading.Tasks.Dataflow;
+
+namespace Advent_of_Code.SharedLibrary.IntcodeVirtualMachine.Input_OutputProviders
+{
+    public class BufferOutputProvider : IOutputProvider
+    {
+        private readonly BufferBlock<long> _outputBuffer;
+        public BufferOutputProvider(BufferBlock<long> outputBuffer)
+        {
+            _outputBuffer = outputBuffer;
+        }
+
+        public void SendOutput(long output)
+        {
+            _outputBuffer.Post(output);
+            Log.Information("BufferOutputProvider Posted output {output}", output);
+        }
+    }
+}

--- a/Advent of Code/SharedLibrary/IntcodeVirtualMachine/Tests/Test_RunningIntcodeVMAsync.cs
+++ b/Advent of Code/SharedLibrary/IntcodeVirtualMachine/Tests/Test_RunningIntcodeVMAsync.cs
@@ -1,0 +1,53 @@
+﻿using Advent_of_Code.Day_07;
+using Advent_of_Code.SharedLibrary.IntcodeVirtualMachine.Input_OutputProviders;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Xunit;
+
+namespace Advent_of_Code.SharedLibrary.IntcodeVirtualMachine.Tests
+{
+    public class Test_RunningIntcodeVMAsync
+    {
+        [Fact]
+        public void ShouldReturnDay2AsAsync()
+        {
+            // Arrange 
+            List<int> program = SharedLibrary.FileParser.GetIntCodeFromFile(@"Inputs\Day02Input.txt");
+
+            // Act
+            IntcodeVirtualMachine intMachine = new IntcodeVirtualMachine(program);
+            long actual = 0;
+            var runningTask = Task.Run(() => { actual = intMachine.Run(); });
+            runningTask.Wait();
+
+            // Assert
+            Assert.Equal(4570637, actual);
+        }
+
+        [Fact]
+        public void ShouldUseAsyncOutputProvider()
+        {
+            // Arrange 
+            int input = 99798;
+            int expected = input;
+            List<int> program = new List<int>() { 3, 0, 4, 0, 99 };
+            BufferBlock<long> inputBuffer = new BufferBlock<long>();
+            BufferBlock<long> outputBuffer = new BufferBlock<long>();
+            IInputProvider inputProvider = new BufferInputProvider(inputBuffer);
+            IOutputProvider outputProvider = new BufferOutputProvider(outputBuffer);
+            IntcodeVirtualMachine virtualMachine = new IntcodeVirtualMachine(program, inputProvider, outputProvider);
+
+            // Act
+            var vmTask = Task.Run(() => { virtualMachine.Run(); });
+            inputBuffer.Post(input);
+            vmTask.Wait();
+
+            // Assert
+            long actual = outputBuffer.Receive();
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Refactor day 07 to use `Task.Run` to use new threads for each intcodeVM instance. 

Use `BufferBlock` to facilitate inter-process communication.